### PR TITLE
Simplify `DataProcessor.process/1`

### DIFF
--- a/lib/data_processor.ex
+++ b/lib/data_processor.ex
@@ -4,15 +4,10 @@ defmodule DataProcessor do
                "Electronic Travel Authorization", "Permit on arrival"]
   def process(list) do
     [first | rest] = Enum.map(list, &process_data/1)
-    Enum.reduce(first, [], fn country, acc ->
-      present_in_all = Enum.all?(rest, fn countries -> 
+    Enum.filter(first, fn country ->
+      Enum.all?(rest, fn countries ->
         Enum.member?(Enum.map(countries, &String.downcase/1), String.downcase(country))
       end)
-      if present_in_all do
-        [country | acc]
-      else
-        acc
-      end
     end)
   end
 


### PR DESCRIPTION
The `reduce` call in this funciton was just a fancy way to write `filter`.

I tested this stuff manually on `ru,by,pl,bg,kz` - seems to work fine.